### PR TITLE
In tutorial, it's easy to miss that enableAuth in your screenshot is set to false

### DIFF
--- a/lib/secret.js.sample
+++ b/lib/secret.js.sample
@@ -12,5 +12,5 @@ module.exports = {
     "redisPort": 6379,
     "redisMachine": "",
     "redisAuth": "",
-    "enableAuth": true
+    "enableAuth": false
 };                                                                        


### PR DESCRIPTION
By setting it to false here, it can be explicitly set to true when dual auth is implemented in a later step
